### PR TITLE
code review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
- "uuid",
 ]
 
 [[package]]
@@ -1588,17 +1587,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "uuid"
-version = "1.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
-dependencies = [
- "getrandom",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ serde_bencode = "0.2"
 thiserror = "2.0"
 
 # Utilities
-uuid = { version = "1.11", features = ["v4"] }
 lazy_static = "1.5"
 
 # Steel FFI (only for steel-nrepl crate)

--- a/crates/nrepl-rs/Cargo.toml
+++ b/crates/nrepl-rs/Cargo.toml
@@ -13,7 +13,6 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_bencode = { workspace = true }
 thiserror = { workspace = true }
-uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/crates/nrepl-rs/src/message.rs
+++ b/crates/nrepl-rs/src/message.rs
@@ -151,7 +151,7 @@ pub struct Response {
 pub struct EvalResult {
     pub value: Option<String>,
     pub output: Vec<String>,
-    pub error: Option<String>,
+    pub error: Vec<String>,
     pub ns: Option<String>,
 }
 
@@ -160,7 +160,7 @@ impl EvalResult {
         Self {
             value: None,
             output: Vec::new(),
-            error: None,
+            error: Vec::new(),
             ns: None,
         }
     }
@@ -169,5 +169,19 @@ impl EvalResult {
 impl Default for EvalResult {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eval_result_is_send_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        assert_send::<EvalResult>();
+        assert_sync::<EvalResult>();
     }
 }

--- a/crates/nrepl-rs/src/ops.rs
+++ b/crates/nrepl-rs/src/ops.rs
@@ -12,13 +12,25 @@
 
 /// nREPL operation builders
 use crate::message::Request;
-use uuid::Uuid;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Global counter for generating sequential request IDs
+static REQUEST_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
+
+/// Generate a unique request ID
+///
+/// Uses a global atomic counter to generate sequential IDs starting from 1.
+/// Thread-safe and guaranteed to produce unique IDs within a single process.
+fn next_request_id() -> String {
+    let id = REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("req-{}", id)
+}
 
 /// Helper to create a base request with just op and id
 fn base_request(op: &str) -> Request {
     Request {
         op: op.to_string(),
-        id: Uuid::new_v4().to_string(),
+        id: next_request_id(),
         session: None,
         code: None,
         file: None,

--- a/crates/nrepl-rs/src/session.rs
+++ b/crates/nrepl-rs/src/session.rs
@@ -13,12 +13,17 @@
 /// Represents an nREPL session
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Session {
-    pub id: String,
+    id: String,
 }
 
 impl Session {
-    pub fn new(id: impl Into<String>) -> Self {
+    pub(crate) fn new(id: impl Into<String>) -> Self {
         Self { id: id.into() }
+    }
+
+    /// Get the session ID
+    pub fn id(&self) -> &str {
+        &self.id
     }
 }
 
@@ -41,9 +46,9 @@ mod tests {
         // Test that sessions can be sorted
         let mut sessions = vec![session_c.clone(), session_a.clone(), session_b.clone()];
         sessions.sort();
-        assert_eq!(sessions[0].id, "aaa");
-        assert_eq!(sessions[1].id, "bbb");
-        assert_eq!(sessions[2].id, "ccc");
+        assert_eq!(sessions[0].id(), "aaa");
+        assert_eq!(sessions[1].id(), "bbb");
+        assert_eq!(sessions[2].id(), "ccc");
     }
 
     #[test]

--- a/crates/steel-nrepl/src/connection.rs
+++ b/crates/steel-nrepl/src/connection.rs
@@ -54,10 +54,11 @@ fn eval_result_to_steel_hashmap(result: &EvalResult) -> String {
         .collect();
     parts.push(format!("'output (list {})", output_items.join(" ")));
 
-    // Add 'error
-    let error_str = match &result.error {
-        Some(e) => format!("\"{}\"", escape_steel_string(e)),
-        None => "#f".to_string(),
+    // Add 'error - join multiple errors with newlines, or #f if none
+    let error_str = if result.error.is_empty() {
+        "#f".to_string()
+    } else {
+        format!("\"{}\"", escape_steel_string(&result.error.join("\n")))
     };
     parts.push(format!("'error {}", error_str));
 


### PR DESCRIPTION
 - Add Drop implementation warning for NReplClient with unclosed sessions
 - Add MAX_STRING_LENGTH check in codec.rs find_bencode_end
 - Add incomplete read counter to prevent DoS via incomplete messages
 - Add HashSet to track timed-out request IDs for proper cleanup
 - Add Send/Sync test for EvalResult in message.rs
 - Make Session.id field private with getter method
 - Make Session.id field private with getter method (MEDIUM-1)
 - Migrate NReplError to use thiserror derive macros (MEDIUM-2)
 - Add connection reuse patterns documentation to NReplClient (MEDIUM-3)
 - Change EvalResult.error to Vec<String> for efficiency (MEDIUM-4)
 - Add MAX_OUTPUT_ENTRIES and MAX_OUTPUT_TOTAL_SIZE limits (MEDIUM-5)
 - Add custom Debug implementation for NReplClient (LOW-1)
 - Fix codec module visibility (make truly private or document public API) (LOW-2)
 - Add documentation explaining shutdown() consumes self (API-2)
 - Add sessions() method to query active sessions (API-3)
 - Add is_connected() health check method (API-4)
 - Add troubleshooting and security documentation (DOC-2, SEC-3)
 - Standardize timeout errors to use NReplError::Timeout variant (API-1)
 - Add test for codec integer overflow protection (TEST-3)
 - Replace UUID dependency with sequential request IDs (LOW-3)