### PR TITLE
code review 2

### DIFF
--- a/crates/nrepl-rs/src/lib.rs
+++ b/crates/nrepl-rs/src/lib.rs
@@ -292,6 +292,18 @@
 //! - Buffer management operations
 //! - Stream read activity
 //!
+//! ### Security Warning
+//!
+//! **⚠️ Debug logs may contain sensitive information:**
+//! - Source code being evaluated (may include secrets, credentials, API keys)
+//! - Evaluation results and output
+//! - Session IDs
+//! - Buffer contents in hexadecimal format
+//!
+//! **Never enable debug logging in production environments.** Only use it during
+//! development and debugging, and ensure debug logs are not committed to version
+//! control or exposed to unauthorized users.
+//!
 //! ## Troubleshooting
 //!
 //! ### Connection Errors

--- a/crates/nrepl-rs/src/session.rs
+++ b/crates/nrepl-rs/src/session.rs
@@ -11,7 +11,19 @@
 // GNU Affero General Public License for more details.
 
 /// Represents an nREPL session
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
+///
+/// # Security Note
+///
+/// Session objects can only be created through controlled paths to prevent session
+/// hijacking attacks:
+/// - `NReplClient::clone_session()` - Creates a new session on the server
+/// - `Session::new()` - Internal constructor (crate-private) for server-provided IDs
+///
+/// **`Deserialize` is intentionally NOT implemented** to prevent malicious code from
+/// constructing `Session` objects with arbitrary IDs from untrusted data sources
+/// (config files, user input, network data). Such deserialization would enable
+/// session hijacking where an attacker provides another user's session ID.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
 pub struct Session {
     id: String,
 }
@@ -59,9 +71,7 @@ mod tests {
         let json = serde_json::to_string(&session).expect("Failed to serialize");
         assert!(json.contains("test-session-123"));
 
-        // Test Deserialize
-        let deserialized: Session = serde_json::from_str(&json).expect("Failed to deserialize");
-        assert_eq!(deserialized.id, "test-session-123");
-        assert_eq!(deserialized, session);
+        // Note: Deserialize is intentionally NOT implemented for security reasons
+        // (prevents session hijacking via untrusted data deserialization)
     }
 }

--- a/crates/nrepl-rs/tests/integration.rs
+++ b/crates/nrepl-rs/tests/integration.rs
@@ -250,4 +250,665 @@ mod real_server_tests {
             result.err()
         );
     }
+
+    /// Test persistent buffer handling with multiple output chunks
+    ///
+    /// This test verifies that NReplClient's persistent buffer correctly handles
+    /// multiple bencode messages that may arrive in rapid succession or within
+    /// a single TCP read. The server typically sends multiple responses:
+    /// - One or more messages with output/errors (status: [])
+    /// - A final message with value and "done" status
+    ///
+    /// The persistent buffer ensures no messages are lost when multiple arrive
+    /// in one TCP packet, and correctly handles partial messages split across reads.
+    #[tokio::test]
+    #[ignore]
+    async fn test_buffer_handles_multiple_output_chunks() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+        let session = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session");
+
+        // Evaluate code that produces multiple output chunks
+        // This will cause the server to send multiple response messages:
+        // - Message with "chunk 1" output
+        // - Message with "chunk 2" output
+        // - Message with "chunk 3" output
+        // - Final message with value and "done" status
+        let result = client
+            .eval(
+                &session,
+                r#"(do
+                     (println "chunk 1")
+                     (println "chunk 2")
+                     (println "chunk 3")
+                     (+ 1 2))"#,
+            )
+            .await;
+
+        assert!(result.is_ok(), "Eval failed: {:?}", result.err());
+
+        let result = result.unwrap();
+        assert_eq!(result.value, Some("3".to_string()), "Expected value 3");
+
+        // Verify all output chunks were received
+        // (may be combined or separate depending on server behavior)
+        let combined_output = result.output.join("");
+        assert!(
+            combined_output.contains("chunk 1"),
+            "Should contain 'chunk 1'"
+        );
+        assert!(
+            combined_output.contains("chunk 2"),
+            "Should contain 'chunk 2'"
+        );
+        assert!(
+            combined_output.contains("chunk 3"),
+            "Should contain 'chunk 3'"
+        );
+    }
+
+    /// Test persistent buffer with large output
+    ///
+    /// This verifies the buffer can handle large responses that may be split
+    /// across multiple TCP reads, or multiple messages that arrive in one read.
+    #[tokio::test]
+    #[ignore]
+    async fn test_buffer_handles_large_output() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+        let session = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session");
+
+        // Generate a large string (10KB) which may be split across multiple messages
+        let result = client
+            .eval(
+                &session,
+                r#"(apply str (repeat 10000 "x"))"#,
+            )
+            .await;
+
+        assert!(result.is_ok(), "Eval failed: {:?}", result.err());
+
+        let result = result.unwrap();
+        assert!(result.value.is_some(), "Should have a value");
+        let value = result.value.unwrap();
+        assert_eq!(
+            value.len(),
+            10000,
+            "Should return string of exactly 10000 characters"
+        );
+        assert!(
+            value.chars().all(|c| c == 'x'),
+            "String should contain only 'x' characters"
+        );
+    }
+
+    /// Test persistent buffer with rapid sequential evaluations
+    ///
+    /// This tests that the buffer correctly handles back-to-back evaluations
+    /// where responses might arrive in rapid succession or overlap.
+    #[tokio::test]
+    #[ignore]
+    async fn test_buffer_handles_rapid_evaluations() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+        let session = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session");
+
+        // Perform multiple rapid evaluations
+        for i in 1..=10 {
+            let result = client
+                .eval(&session, format!("(+ {} {})", i, i))
+                .await;
+
+            assert!(result.is_ok(), "Eval {} failed: {:?}", i, result.err());
+
+            let result = result.unwrap();
+            assert_eq!(
+                result.value,
+                Some((i + i).to_string()),
+                "Eval {} should return {}",
+                i,
+                i + i
+            );
+        }
+    }
+
+    /// Test partial message handling across TCP reads
+    ///
+    /// This test uses a large code string that's likely to result in responses
+    /// that span multiple TCP packets, testing that the buffer correctly
+    /// accumulates partial messages until complete.
+    #[tokio::test]
+    #[ignore]
+    async fn test_buffer_handles_partial_messages() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+        let session = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session");
+
+        // Create a large code string (with comments to increase size)
+        // The response will be large enough to likely span multiple TCP reads
+        let large_code = format!(
+            r#"(do
+                 ;; Comment: {}
+                 (let [data (apply str (repeat 1000 "test data "))]
+                   (count data)))"#,
+            "x".repeat(1000)
+        );
+
+        let result = client.eval(&session, large_code).await;
+
+        assert!(result.is_ok(), "Eval failed: {:?}", result.err());
+
+        let result = result.unwrap();
+        // "test data " is 10 chars, repeated 1000 times = 10000
+        assert_eq!(
+            result.value,
+            Some("10000".to_string()),
+            "Should return correct count"
+        );
+    }
+
+    /// Test MAX_OUTPUT_ENTRIES DoS protection
+    ///
+    /// Verifies that the client protects against DoS attacks via excessive output
+    /// flooding. The limit is 10,000 output entries per evaluation.
+    ///
+    /// This prevents a malicious or buggy server from exhausting client memory
+    /// by sending unlimited output responses.
+    #[tokio::test]
+    #[ignore]
+    async fn test_max_output_entries_protection() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+        let session = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session");
+
+        // Try to generate more than 10,000 output entries
+        // Each println creates one output entry
+        // We use 10,100 to exceed the limit
+        let result = client
+            .eval(
+                &session,
+                r#"(dotimes [i 10100] (println i))"#,
+            )
+            .await;
+
+        // The evaluation should fail with a protocol error about exceeding the limit
+        assert!(
+            result.is_err(),
+            "Should fail when exceeding MAX_OUTPUT_ENTRIES (10,000)"
+        );
+
+        let err = result.unwrap_err();
+        match err {
+            NReplError::Protocol { ref message } => {
+                assert!(
+                    message.contains("maximum entries limit") || message.contains("10000") || message.contains("10,000"),
+                    "Error should mention entries limit, got: {}",
+                    message
+                );
+            }
+            other => panic!("Expected Protocol error about entries limit, got: {:?}", other),
+        }
+    }
+
+    /// Test that output under the limit works fine
+    ///
+    /// This verifies that evaluations producing output close to but under the
+    /// MAX_OUTPUT_ENTRIES limit (10,000) complete successfully.
+    #[tokio::test]
+    #[ignore]
+    async fn test_output_entries_under_limit() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+        let session = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session");
+
+        // Generate 1,000 output entries (well under the 10,000 limit)
+        let result = client
+            .eval(
+                &session,
+                r#"(dotimes [i 1000] (println i))"#,
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "Should succeed with 1,000 entries (under 10,000 limit): {:?}",
+            result.err()
+        );
+
+        let result = result.unwrap();
+        // Should have 1000 output entries
+        assert!(
+            result.output.len() <= 1000,
+            "Should have at most 1000 output entries"
+        );
+    }
+
+    /// Test MAX_RESPONSE_SIZE DoS protection
+    ///
+    /// Verifies that the client protects against DoS attacks via extremely large
+    /// responses. The limit is 10MB (10,485,760 bytes) for any single response.
+    ///
+    /// This prevents a malicious server from exhausting client memory by sending
+    /// unlimited response data.
+    #[tokio::test]
+    #[ignore]
+    async fn test_max_response_size_protection() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+        let session = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session");
+
+        // Try to generate a response larger than 10MB
+        // 11MB = 11 * 1024 * 1024 = 11,534,336 bytes
+        // We create a string of this size which will be sent back in the response
+        let result = client
+            .eval(
+                &session,
+                r#"(apply str (repeat 11534336 "x"))"#,
+            )
+            .await;
+
+        // The evaluation should fail with a protocol error about exceeding size
+        assert!(
+            result.is_err(),
+            "Should fail when response exceeds MAX_RESPONSE_SIZE (10MB)"
+        );
+
+        let err = result.unwrap_err();
+        match err {
+            NReplError::Protocol { ref message } => {
+                assert!(
+                    message.contains("maximum size") || message.contains("10") || message.contains("MB"),
+                    "Error should mention size limit, got: {}",
+                    message
+                );
+            }
+            other => panic!("Expected Protocol error about size limit, got: {:?}", other),
+        }
+    }
+
+    /// Test MAX_OUTPUT_TOTAL_SIZE DoS protection
+    ///
+    /// Verifies protection against excessive combined stdout+stderr output size.
+    /// The limit is 10MB total for all output accumulated during an evaluation.
+    ///
+    /// This is separate from MAX_OUTPUT_ENTRIES (which limits number of entries)
+    /// and prevents a few very large output strings from exhausting memory.
+    #[tokio::test]
+    #[ignore]
+    async fn test_max_output_total_size_protection() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+        let session = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session");
+
+        // Try to print more than 10MB of output
+        // Print 100 strings of 120KB each = 12MB total
+        let result = client
+            .eval(
+                &session,
+                r#"(dotimes [i 100]
+                     (println (apply str (repeat 122880 "x"))))"#,
+            )
+            .await;
+
+        // The evaluation should fail with a protocol error about total size
+        assert!(
+            result.is_err(),
+            "Should fail when output exceeds MAX_OUTPUT_TOTAL_SIZE (10MB)"
+        );
+
+        let err = result.unwrap_err();
+        match err {
+            NReplError::Protocol { ref message } => {
+                assert!(
+                    message.contains("maximum total size") || message.contains("10") || message.contains("MB"),
+                    "Error should mention total size limit, got: {}",
+                    message
+                );
+            }
+            other => panic!("Expected Protocol error about total size limit, got: {:?}", other),
+        }
+    }
+
+    /// Test that large but acceptable responses work
+    ///
+    /// This verifies that responses close to but under the 10MB limit
+    /// complete successfully.
+    #[tokio::test]
+    #[ignore]
+    async fn test_response_size_under_limit() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+        let session = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session");
+
+        // Generate a 1MB string (well under the 10MB limit)
+        let result = client
+            .eval(
+                &session,
+                r#"(apply str (repeat 1048576 "x"))"#,
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "Should succeed with 1MB response (under 10MB limit): {:?}",
+            result.err()
+        );
+
+        let result = result.unwrap();
+        assert!(result.value.is_some(), "Should have a value");
+        let value = result.value.unwrap();
+        assert_eq!(
+            value.len(),
+            1048576,
+            "Should return 1MB string"
+        );
+    }
+
+    /// Test session isolation
+    ///
+    /// Verifies that multiple sessions maintain independent evaluation contexts.
+    /// Variables, namespaces, and state defined in one session should not be
+    /// visible in another session.
+    #[tokio::test]
+    #[ignore]
+    async fn test_session_isolation() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+
+        // Create two independent sessions
+        let session1 = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session 1");
+        let session2 = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session 2");
+
+        // Verify sessions have different IDs
+        assert_ne!(
+            session1.id(),
+            session2.id(),
+            "Sessions should have different IDs"
+        );
+
+        // Define a variable in session 1
+        let result = client.eval(&session1, "(def session1-var 42)").await;
+        assert!(result.is_ok(), "Failed to define var in session 1");
+
+        // Verify session 1 can see its own variable
+        let result = client.eval(&session1, "session1-var").await;
+        assert!(result.is_ok(), "Failed to eval var in session 1");
+        assert_eq!(
+            result.unwrap().value,
+            Some("42".to_string()),
+            "Session 1 should see its own variable"
+        );
+
+        // Verify session 2 CANNOT see session 1's variable
+        let result = client.eval(&session2, "session1-var").await;
+        // This should either fail or return an error in the result
+        // (depending on server behavior - some return errors, some throw exceptions)
+        if let Ok(result) = result {
+            assert!(
+                !result.error.is_empty() || result.value.is_none(),
+                "Session 2 should not see session 1's variable"
+            );
+        }
+
+        // Define a different variable in session 2
+        let result = client.eval(&session2, "(def session2-var 99)").await;
+        assert!(result.is_ok(), "Failed to define var in session 2");
+
+        // Verify session 2 can see its own variable
+        let result = client.eval(&session2, "session2-var").await;
+        assert!(result.is_ok(), "Failed to eval var in session 2");
+        assert_eq!(
+            result.unwrap().value,
+            Some("99".to_string()),
+            "Session 2 should see its own variable"
+        );
+
+        // Verify session 1 CANNOT see session 2's variable
+        let result = client.eval(&session1, "session2-var").await;
+        if let Ok(result) = result {
+            assert!(
+                !result.error.is_empty() || result.value.is_none(),
+                "Session 1 should not see session 2's variable"
+            );
+        }
+
+        // Verify session 1 still has its original variable
+        let result = client.eval(&session1, "session1-var").await;
+        assert!(result.is_ok(), "Session 1 should still have its variable");
+        assert_eq!(
+            result.unwrap().value,
+            Some("42".to_string()),
+            "Session 1's variable should be unchanged"
+        );
+    }
+
+    /// Test session namespace isolation
+    ///
+    /// Verifies that namespace changes in one session don't affect other sessions.
+    #[tokio::test]
+    #[ignore]
+    async fn test_session_namespace_isolation() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+
+        // Create two independent sessions
+        let session1 = client.clone_session().await.expect("Failed to clone session 1");
+        let session2 = client.clone_session().await.expect("Failed to clone session 2");
+
+        // Switch session 1 to a custom namespace
+        let result = client.eval(&session1, "(ns test.session1)").await;
+        assert!(result.is_ok(), "Failed to switch namespace in session 1");
+        assert_eq!(
+            result.unwrap().ns,
+            Some("test.session1".to_string()),
+            "Session 1 should be in test.session1 namespace"
+        );
+
+        // Verify session 2 is still in default namespace (user)
+        let result = client.eval(&session2, "(str *ns*)").await;
+        assert!(result.is_ok(), "Failed to check namespace in session 2");
+        let ns = result.unwrap().value.unwrap();
+        assert!(
+            ns.contains("user") || ns.contains("default"),
+            "Session 2 should still be in default namespace, got: {}",
+            ns
+        );
+
+        // Switch session 2 to a different namespace
+        let result = client.eval(&session2, "(ns test.session2)").await;
+        assert!(result.is_ok(), "Failed to switch namespace in session 2");
+        assert_eq!(
+            result.unwrap().ns,
+            Some("test.session2".to_string()),
+            "Session 2 should be in test.session2 namespace"
+        );
+
+        // Verify session 1 is still in its original namespace
+        let result = client.eval(&session1, "(str *ns*)").await;
+        assert!(result.is_ok(), "Failed to check namespace in session 1");
+        let ns = result.unwrap().value.unwrap();
+        assert!(
+            ns.contains("test.session1"),
+            "Session 1 should still be in test.session1, got: {}",
+            ns
+        );
+    }
+
+    /// Test close_session removes from tracking
+    ///
+    /// Verifies that when a session is closed, it's properly removed from the
+    /// client's internal session tracking. This prevents memory leaks and ensures
+    /// operations fail appropriately on closed sessions.
+    #[tokio::test]
+    #[ignore]
+    async fn test_close_session_removes_from_tracking() {
+        let mut client = connect_test_server().await.expect("Failed to connect");
+
+        // Verify we start with no sessions
+        assert_eq!(
+            client.sessions().len(),
+            0,
+            "Client should start with no sessions"
+        );
+
+        // Create a session
+        let session1 = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session 1");
+        let session1_id = session1.id().to_string();
+
+        // Verify the session is tracked
+        assert_eq!(
+            client.sessions().len(),
+            1,
+            "Client should track 1 session"
+        );
+        assert!(
+            client
+                .sessions()
+                .iter()
+                .any(|s| s.id() == &session1_id),
+            "Client should track session1"
+        );
+
+        // Create a second session
+        let session2 = client
+            .clone_session()
+            .await
+            .expect("Failed to clone session 2");
+        let session2_id = session2.id().to_string();
+
+        // Verify both sessions are tracked
+        assert_eq!(
+            client.sessions().len(),
+            2,
+            "Client should track 2 sessions"
+        );
+
+        // Close session1
+        let close_result = client.close_session(session1).await;
+        assert!(close_result.is_ok(), "Failed to close session1");
+
+        // Verify session1 is no longer tracked
+        assert_eq!(
+            client.sessions().len(),
+            1,
+            "Client should track 1 session after closing one"
+        );
+        assert!(
+            !client
+                .sessions()
+                .iter()
+                .any(|s| s.id() == &session1_id),
+            "Client should not track session1 after closing"
+        );
+        assert!(
+            client
+                .sessions()
+                .iter()
+                .any(|s| s.id() == &session2_id),
+            "Client should still track session2"
+        );
+
+        // Verify session1 cannot be used after closing (by checking it's not in tracking)
+        // Note: We can't actually eval on session1 because close_session() consumes it
+        // The tracking check above is sufficient
+
+        // Close session2
+        let close_result = client.close_session(session2).await;
+        assert!(close_result.is_ok(), "Failed to close session2");
+
+        // Verify no sessions are tracked
+        assert_eq!(
+            client.sessions().len(),
+            0,
+            "Client should track 0 sessions after closing all"
+        );
+    }
+
+    /// Test register_session and session tracking
+    ///
+    /// Verifies that register_session() properly adds a session to the client's
+    /// internal tracking, enabling it to be used with operations like eval().
+    #[tokio::test]
+    #[ignore]
+    async fn test_register_session_tracking() {
+        let mut client1 = connect_test_server().await.expect("Failed to connect client1");
+        let mut client2 = connect_test_server().await.expect("Failed to connect client2");
+
+        // Client 1 creates a session
+        let session = client1
+            .clone_session()
+            .await
+            .expect("Failed to clone session");
+        let session_id = session.id().to_string();
+
+        // Verify client1 tracks the session
+        assert_eq!(
+            client1.sessions().len(),
+            1,
+            "Client1 should track 1 session"
+        );
+
+        // Verify client2 does NOT track the session yet
+        assert_eq!(
+            client2.sessions().len(),
+            0,
+            "Client2 should not track any sessions yet"
+        );
+
+        // Register the session with client2
+        use nrepl_rs::Session;
+        let shared_session = Session::new(session_id.clone());
+        client2.register_session(shared_session.clone());
+
+        // Verify client2 now tracks the session
+        assert_eq!(
+            client2.sessions().len(),
+            1,
+            "Client2 should track 1 session after registration"
+        );
+        assert!(
+            client2
+                .sessions()
+                .iter()
+                .any(|s| s.id() == &session_id),
+            "Client2 should track the registered session"
+        );
+
+        // Verify both clients can use the session
+        let result1 = client1.eval(&session, "(def shared-var 42)").await;
+        assert!(result1.is_ok(), "Client1 should be able to eval on session");
+
+        let result2 = client2.eval(&shared_session, "shared-var").await;
+        assert!(result2.is_ok(), "Client2 should be able to eval on registered session");
+        assert_eq!(
+            result2.unwrap().value,
+            Some("42".to_string()),
+            "Client2 should see variable defined by client1 (same session)"
+        );
+    }
 }


### PR DESCRIPTION
 - Add register_session() method to NReplClient for explicit session import
 - Update session sharing documentation to match implementation behavior
 - Add clarifying comments about timeout cleanup being safe due to &mut self constraint
 - Document that output size limits combine stdout+stderr
 - Add tests for persistent buffer handling multiple messages in one TCP read
 - Add integration test for MAX_OUTPUT_ENTRIES DoS protection
 - Add integration test for MAX_RESPONSE_SIZE DoS protection
 - Add test_session_isolation() for verifying multiple sessions coexist independently
 - Add test_close_session_removes_from_tracking() to verify session cleanup
 - Remove Deserialize from Session to prevent session hijacking
 - Add security warning to documentation that NREPL_DEBUG may leak sensitive data
 - Rename is_connected() to test_connectivity() to reflect active operation