### PR TITLE
steel-nrepl review 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,10 +448,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
@@ -1034,6 +1061,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quickscope"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1147,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1172,12 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "repr_offset"
@@ -1153,6 +1221,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1382,6 +1462,7 @@ dependencies = [
  "abi_stable",
  "lazy_static",
  "nrepl-rs",
+ "proptest",
  "steel-core",
  "steel-derive",
  "tokio",
@@ -1441,6 +1522,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1571,6 +1665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1693,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/crates/nrepl-rs/src/codec.rs
+++ b/crates/nrepl-rs/src/codec.rs
@@ -15,10 +15,10 @@
 /// This module handles encoding and decoding of nREPL messages using bencode format.
 ///
 /// Bencode format:
-/// - Strings: <length>:<string> (e.g., "4:spam")
-/// - Integers: i<number>e (e.g., "i42e")
-/// - Lists: l<items>e (e.g., "l4:spam4:eggse")
-/// - Dictionaries: d<key><value>...e (e.g., "d3:cow3:moo4:spam4:eggse")
+/// - Strings: `<length>:<string>` (e.g., "4:spam")
+/// - Integers: `i<number>e` (e.g., "i42e")
+/// - Lists: `l<items>e` (e.g., "l4:spam4:eggse")
+/// - Dictionaries: `d<key><value>...e` (e.g., "d3:cow3:moo4:spam4:eggse")
 use crate::error::{NReplError, Result};
 use crate::message::{Request, Response};
 

--- a/crates/nrepl-rs/src/message.rs
+++ b/crates/nrepl-rs/src/message.rs
@@ -82,7 +82,17 @@ enum BencodeValue {
 impl BencodeValue {
     fn to_string_repr(&self) -> String {
         match self {
-            BencodeValue::String(s) => s.clone(),
+            BencodeValue::String(s) => {
+                // Strip surrounding quotes from Clojure string values
+                // Clojure returns string values as "..." (with quotes)
+                // We want to return the actual string content without quotes
+                if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+                    // Remove the surrounding quotes
+                    s[1..s.len()-1].to_string()
+                } else {
+                    s.clone()
+                }
+            }
             BencodeValue::Int(i) => i.to_string(),
             BencodeValue::List(list) => {
                 let items: Vec<String> = list.iter().map(|v| v.to_string_repr()).collect();

--- a/crates/steel-nrepl/Cargo.toml
+++ b/crates/steel-nrepl/Cargo.toml
@@ -16,3 +16,6 @@ steel-derive = { git = "https://github.com/mattwparas/steel.git", version = "0.6
 tokio = { workspace = true, features = ["full"] }
 lazy_static = { workspace = true }
 abi_stable = "0.11"
+
+[dev-dependencies]
+proptest = "1.5"

--- a/crates/steel-nrepl/proptest-regressions/connection.txt
+++ b/crates/steel-nrepl/proptest-regressions/connection.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 41431d262fa84782bdf4b0fbe42fed6b1070e83fcec03d41a1b54dc23d367249 # shrinks to s = "\\¡"


### PR DESCRIPTION
 - Fix clippy error: Remove empty line after doc comment (registry.rs:277)
 - Fix clippy error: Add #[allow(clippy::new_without_default)] to Worker::new() (worker.rs:89)
 - Fix clippy error: Change assert_eq!(bool, false) to assert!(!bool) (registry.rs:398)
 - Fix request ID overflow: Add checked_add to match documentation (worker.rs:213, 241)
 - Add session ID overflow protection with checked_add (registry.rs:190)
 - Add connection ID overflow protection with checked_add (registry.rs:89)
 - Use single-threaded Tokio runtime: Change Runtime::new() to Builder::new_current_thread() (worker.rs:95)
 - Add MAX_PENDING_RESPONSES limit to prevent unbounded HashMap growth (worker.rs:84)
 - Add crate-level documentation to lib.rs explaining architecture and usage
 - Add test: Empty string output edge case (connection.rs)
 - Add test: Double close behavior (connection.rs)
 - Add test: Failed connection doesn't waste ID (registry.rs)
 - Add test: Unicode and emoji string escaping (connection.rs)
 - Add test: Unbounded response buffer growth (worker.rs)
 - Add code size validation: MAX_CODE_SIZE limit (connection.rs:93, 117, 157)
 - Implement newtypes for ConnectionId, SessionId, RequestId for stronger type safety
 - Implement newtypes for ConnectionId, SessionId, RequestId for stronger type safety
 - Add property-based testing with proptest for string escaping
 - Fix cargo doc warnings: escape HTML-like angle brackets in bencode format documentation