### PR TITLE
better dropped connection handling

### DIFF
--- a/crates/nrepl-rs/src/connection.rs
+++ b/crates/nrepl-rs/src/connection.rs
@@ -1699,8 +1699,8 @@ impl std::fmt::Debug for NReplClient {
 impl Drop for NReplClient {
     fn drop(&mut self) {
         if !self.sessions.is_empty() {
-            eprintln!(
-                "Warning: NReplClient dropped with {} active session(s). \
+            debug_log!(
+                "[nREPL DEBUG] Warning: NReplClient dropped with {} active session(s). \
                  Call shutdown() for graceful cleanup to close server-side sessions.",
                 self.sessions.len()
             );


### PR DESCRIPTION
- Change Drop warning to debug_log! in connection.rs
- Add response channel to WorkerCommand::Shutdown
- Call client.shutdown() in worker thread and wait for completion
- Simplify nrepl_close to remove blocking session close loop