### PR TITLE
completions/lookup

### DIFF
--- a/crates/nrepl-rs/examples/simple_eval.rs
+++ b/crates/nrepl-rs/examples/simple_eval.rs
@@ -13,12 +13,12 @@
 //! Simple example demonstrating nREPL client usage
 //!
 //! Start an nREPL server first:
-//! ```bash
+//! ```sh
 //! clj -Sdeps '{:deps {nrepl/nrepl {:mvn/version "1.1.0"}}}' -M -m nrepl.cmdline --port 7888
 //! ```
 //!
 //! Then run this example:
-//! ```bash
+//! ```sh
 //! cargo run -p nrepl-rs --example simple_eval
 //! ```
 

--- a/crates/nrepl-rs/src/connection.rs
+++ b/crates/nrepl-rs/src/connection.rs
@@ -1186,7 +1186,10 @@ impl NReplClient {
     ///
     /// # Returns
     ///
-    /// Returns a vector of completion strings (e.g., ["map-indexed", "mapcat", "mapv"]).
+    /// Returns a vector of completion candidates with structured metadata. Each candidate includes:
+    /// - `candidate`: The completion string (e.g., "map-indexed", "mapcat", "mapv")
+    /// - `ns`: The namespace where the symbol is defined (e.g., "clojure.core")
+    /// - `candidate_type`: The type of symbol (e.g., "function", "macro", "var")
     ///
     /// # Errors
     ///
@@ -1204,8 +1207,12 @@ impl NReplClient {
     ///
     /// // Get completions for "map-"
     /// let completions = client.completions(&session, "map-", None, None).await?;
-    /// for completion in completions {
-    ///     println!("  {}", completion);
+    /// for completion in &completions {
+    ///     println!("  {} ({}::{})",
+    ///         completion.candidate,
+    ///         completion.ns.as_deref().unwrap_or("unknown"),
+    ///         completion.candidate_type.as_deref().unwrap_or("unknown")
+    ///     );
     /// }
     /// # Ok(())
     /// # }
@@ -1216,7 +1223,7 @@ impl NReplClient {
         prefix: impl Into<String>,
         ns: Option<String>,
         complete_fn: Option<String>,
-    ) -> Result<Vec<String>> {
+    ) -> Result<Vec<crate::message::CompletionCandidate>> {
         self.validate_session(session)?;
         let prefix_str = prefix.into();
         debug_log!(

--- a/crates/nrepl-rs/src/message.rs
+++ b/crates/nrepl-rs/src/message.rs
@@ -120,6 +120,97 @@ where
     Ok(value.map(|v| v.to_string_repr()))
 }
 
+/// Convert a map of bencode values to a map of string representations
+/// Used for lookup info which contains mixed value types (strings, lists, etc.)
+///
+/// **Special handling**: cider-nrepl sends an empty list `[]` when a symbol doesn't exist,
+/// instead of an empty map or null. This deserializer handles that case gracefully.
+fn deserialize_info_map<'de, D>(
+    deserializer: D,
+) -> Result<Option<BTreeMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Try to deserialize as BencodeValue to handle both map and list cases
+    let value: Option<BencodeValue> = Option::deserialize(deserializer)?;
+
+    match value {
+        Some(BencodeValue::Dict(map)) => {
+            // Normal case: map with symbol info
+            Ok(Some(map.into_iter()
+                .map(|(k, v)| (k, v.to_string_repr()))
+                .collect()))
+        }
+        Some(BencodeValue::List(_)) => {
+            // cider-nrepl sends empty list [] for unknown symbols
+            // Treat as None (no info available)
+            Ok(None)
+        }
+        _ => {
+            // None or other types
+            Ok(None)
+        }
+    }
+}
+
+/// Convert aux field which can contain nested structures from cider-nrepl
+///
+/// **Special handling**: cider-nrepl sends nested dictionaries in aux field
+/// (e.g., `{"cider-version": {"major": 0, "minor": 50, ...}}`).
+/// This deserializer flattens or converts nested structures to strings.
+fn deserialize_aux_map<'de, D>(
+    deserializer: D,
+) -> Result<Option<BTreeMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: Option<BTreeMap<String, BencodeValue>> = Option::deserialize(deserializer)?;
+    Ok(value.map(|m| {
+        m.into_iter()
+            .map(|(k, v)| (k, v.to_string_repr()))
+            .collect()
+    }))
+}
+
+/// Convert nested ops/versions maps from describe operation
+///
+/// **Special handling**: cider-nrepl sends nested dictionaries with BencodeValue types
+/// in the ops and versions fields. This deserializer converts all nested values to strings.
+fn deserialize_nested_map<'de, D>(
+    deserializer: D,
+) -> Result<Option<BTreeMap<String, BTreeMap<String, String>>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: Option<BTreeMap<String, BTreeMap<String, BencodeValue>>> =
+        Option::deserialize(deserializer)?;
+    Ok(value.map(|outer_map| {
+        outer_map.into_iter()
+            .map(|(outer_key, inner_map)| {
+                let converted_inner: BTreeMap<String, String> = inner_map.into_iter()
+                    .map(|(k, v)| (k, v.to_string_repr()))
+                    .collect();
+                (outer_key, converted_inner)
+            })
+            .collect()
+    }))
+}
+
+/// Represents a single completion candidate returned by the completions operation
+///
+/// The nREPL completions middleware returns structured data for each completion:
+/// - `candidate`: The completion string (e.g., "map", "reduce")
+/// - `ns`: The namespace where the symbol is defined (e.g., "clojure.core")
+/// - `type`: The type of the symbol (e.g., "function", "macro", "var")
+#[derive(Debug, Clone, Deserialize)]
+pub struct CompletionCandidate {
+    pub candidate: String,
+    #[serde(default)]
+    pub ns: Option<String>,
+    #[serde(default, rename = "type")]
+    pub candidate_type: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Response {
     pub id: String,
@@ -141,14 +232,18 @@ pub struct Response {
     pub sessions: Option<Vec<String>>,
 
     // completions operation
-    pub completions: Option<Vec<String>>,
+    pub completions: Option<Vec<CompletionCandidate>>,
 
     // describe operation
+    #[serde(default, deserialize_with = "deserialize_nested_map")]
     pub ops: Option<BTreeMap<String, BTreeMap<String, String>>>,
+    #[serde(default, deserialize_with = "deserialize_nested_map")]
     pub versions: Option<BTreeMap<String, BTreeMap<String, String>>>,
+    #[serde(default, deserialize_with = "deserialize_aux_map")]
     pub aux: Option<BTreeMap<String, String>>,
 
     // lookup operation
+    #[serde(default, deserialize_with = "deserialize_info_map")]
     pub info: Option<BTreeMap<String, String>>,
 
     // middleware operations

--- a/crates/steel-nrepl/README.md
+++ b/crates/steel-nrepl/README.md
@@ -72,14 +72,14 @@ Closes a connection and all its sessions. **Always call this!**
 
 ## Building
 
-```bash
+```sh
 cargo build --release -p steel-nrepl
 # Output: target/release/libsteel_nrepl.dylib (or .so/.dll)
 ```
 
 Install to Steel's native library directory:
 
-```bash
+```sh
 cp target/release/libsteel_nrepl.dylib ~/.steel/native/
 ```
 

--- a/crates/steel-nrepl/src/connection.rs
+++ b/crates/steel-nrepl/src/connection.rs
@@ -511,9 +511,10 @@ pub fn nrepl_completions(
         .map_err(nrepl_error_to_steel)?;
 
     // Format as Steel list: (list "item1" "item2" ...)
+    // Extract just the candidate strings from the structured CompletionCandidate objects
     let completion_items: Vec<String> = completions
         .iter()
-        .map(|s| format!("\"{}\"", escape_steel_string(s)))
+        .map(|c| format!("\"{}\"", escape_steel_string(&c.candidate)))
         .collect();
 
     Ok(format!("(list {})", completion_items.join(" ")))

--- a/crates/steel-nrepl/src/registry.rs
+++ b/crates/steel-nrepl/src/registry.rs
@@ -35,7 +35,7 @@
 
 use crate::worker::{EvalResponse, RequestId, SubmitError, Worker};
 use lazy_static::lazy_static;
-use nrepl_rs::{NReplError, Response, Session};
+use nrepl_rs::{CompletionCandidate, NReplError, Response, Session};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -226,7 +226,7 @@ impl Registry {
         prefix: String,
         ns: Option<String>,
         complete_fn: Option<String>,
-    ) -> Result<Vec<String>, NReplError> {
+    ) -> Result<Vec<CompletionCandidate>, NReplError> {
         let worker = &self.connections
             .get(&conn_id)
             .ok_or_else(|| NReplError::protocol(format!(
@@ -421,7 +421,7 @@ pub fn completions_blocking(
     prefix: String,
     ns: Option<String>,
     complete_fn: Option<String>,
-) -> Result<Vec<String>, NReplError> {
+) -> Result<Vec<CompletionCandidate>, NReplError> {
     REGISTRY.lock().unwrap().completions_blocking(conn_id, session, prefix, ns, complete_fn)
 }
 

--- a/crates/steel-nrepl/src/worker.rs
+++ b/crates/steel-nrepl/src/worker.rs
@@ -12,7 +12,7 @@
 
 //! Background worker thread for async nREPL operations
 
-use nrepl_rs::{EvalResult, NReplClient, NReplError, Response, Session};
+use nrepl_rs::{CompletionCandidate, EvalResult, NReplClient, NReplError, Response, Session};
 use std::collections::HashMap;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
@@ -94,7 +94,7 @@ pub enum WorkerCommand {
     CloneSession(Sender<Result<Session, NReplError>>),
     CloseSession(Session, Sender<Result<(), NReplError>>),
     Stdin(Session, String, Sender<Result<(), NReplError>>),
-    Completions(Session, String, Option<String>, Option<String>, Sender<Result<Vec<String>, NReplError>>),
+    Completions(Session, String, Option<String>, Option<String>, Sender<Result<Vec<CompletionCandidate>, NReplError>>),
     Lookup(Session, String, Option<String>, Option<String>, Sender<Result<Response, NReplError>>),
     Shutdown(Sender<Result<(), NReplError>>),
 }
@@ -488,7 +488,7 @@ impl Worker {
         prefix: String,
         ns: Option<String>,
         complete_fn: Option<String>,
-    ) -> Result<Vec<String>, NReplError> {
+    ) -> Result<Vec<CompletionCandidate>, NReplError> {
         let (response_tx, response_rx) = channel();
 
         self.command_tx

--- a/crates/steel-nrepl/tests/registry_stats.rs
+++ b/crates/steel-nrepl/tests/registry_stats.rs
@@ -22,12 +22,12 @@
 //! - Run with: cargo test -p steel-nrepl --test registry_stats -- --ignored
 //!
 //! **Setup:**
-//! ```bash
+//! ```sh
 //! clj -Sdeps '{:deps {nrepl/nrepl {:mvn/version "1.1.0"}}}' -M -m nrepl.cmdline --port 7888
 //! ```
 
-use steel_nrepl::connection::{nrepl_clone_session, nrepl_close, nrepl_connect, nrepl_stats};
 use std::sync::Mutex;
+use steel_nrepl::connection::{nrepl_clone_session, nrepl_close, nrepl_connect, nrepl_stats};
 
 /// Global mutex to serialize tests that check registry stats
 /// This ensures only one test accesses registry stats at a time,
@@ -72,7 +72,10 @@ fn test_ffi_registry_stats_accuracy() {
     // Parse the stats S-expression
     // Expected format: (hash 'total-connections N 'total-sessions M 'max-connections 100
     //                        'next-conn-id X 'connections (list ...))
-    assert!(stats.starts_with("(hash "), "Stats should be a hash S-expression");
+    assert!(
+        stats.starts_with("(hash "),
+        "Stats should be a hash S-expression"
+    );
 
     // Extract total-connections
     let total_connections_str = stats
@@ -120,19 +123,18 @@ fn test_ffi_registry_stats_accuracy() {
     assert!(
         total_connections >= 3,
         "Should have at least 3 connections, got {}. Initial stats: {}",
-        total_connections, initial_stats
+        total_connections,
+        initial_stats
     );
 
     assert!(
         total_sessions >= 6,
         "Should have at least 6 sessions (2+3+1), got {}. Stats: {}",
-        total_sessions, stats
+        total_sessions,
+        stats
     );
 
-    assert_eq!(
-        max_connections, 100,
-        "Max connections should be 100"
-    );
+    assert_eq!(max_connections, 100, "Max connections should be 100");
 
     // Verify connection details list exists
     assert!(


### PR DESCRIPTION
fix completions and lookup operations in nrepl-rs

- Add CompletionCandidate struct to handle structured completion data
- Add custom deserializer for lookup info map (handles mixed value types)
- Update completions() to return Vec<CompletionCandidate> instead of Vec<String>
- Add 6 integration tests for completions and lookup
- Export CompletionCandidate from lib.rs
- Update examples and documentation

fix steel-nrepl to handle CompletionCandidate type from nrepl-rs

- Add CompletionCandidate to imports in worker.rs and registry.rs
- Update WorkerCommand::Completions to use Vec<CompletionCandidate>
- Update completions_blocking return type in worker, registry (method and helper)
- Update connection.rs to extract candidate field from CompletionCandidate
- Steel FFI still returns list of strings, just extracts from structured type

add symbol lookup example and middleware note to nrepl-rs docs

- Add Symbol Lookup example section with code sample
- Add note about middleware requirements for completions/lookup
- Clarify that cider-nrepl middleware is needed for Clojure servers
- Explain timeout/empty results if middleware is missing

fix cider-nrepl deserialization for lookup and describe operations

- Handle empty list [] for unknown symbols in lookup operation
- Handle nested dictionaries in aux field from cider-nrepl
- Handle nested dictionaries in ops/versions fields from describe operation
- Add deserialize_info_map for lookup response info field
- Add deserialize_aux_map for describe response aux field
- Add deserialize_nested_map for ops/versions fields