### PR TITLE
project picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ The jack-in feature automatically starts an nREPL server for your project and co
 :nrepl-jack-in
 
 # Plugin will:
-# 1. Detect project type (deps.edn, bb.edn, or project.clj)
+# 1. Detect project files, presenting a picker if it finds multiple
+# 2. Detect aliases in deps.edn files, presenting a picker if it finds multiple
 # 2. Find a free port (7888-7988 range)
 # 3. Start appropriate nREPL server
 # 4. Write .nrepl-port file

--- a/cogs/nrepl/file-utils.scm
+++ b/cogs/nrepl/file-utils.scm
@@ -1,0 +1,251 @@
+;; Copyright (C) 2025 Tom Waddington
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU Affero General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; file-utils.scm - File System Utilities
+;;;
+;;; Common file system operations for working with project files.
+
+(require-builtin steel/process)
+(require-builtin steel/ports)
+
+(require "cogs/nrepl/sorting-utils.scm")
+
+(provide scan-directory-recursive
+         read-file-preview
+         get-relative-path
+         is-file?
+         is-dir?
+         sort-files-by-distance)
+
+;;;; File System Operations ;;;;
+
+;;@doc
+;; Check if path is a regular file.
+;;
+;; Parameters:
+;;   path - File path to check
+;;
+;; Returns:
+;;   Boolean - #t if path exists and is a file
+(define (is-file? path)
+  (with-handler (lambda (err) #f)
+                (let* ([cmd (command "sh" (list "-c" (string-append "[ -f \"" path "\" ]")))]
+                       [child-result (spawn-process cmd)]
+                       [child (Ok->value child-result)]
+                       [exit-code-result (wait child)]
+                       [exit-code (Ok->value exit-code-result)])
+                  (equal? exit-code 0))))
+
+;;@doc
+;; Check if path is a directory.
+;;
+;; Parameters:
+;;   path - Directory path to check
+;;
+;; Returns:
+;;   Boolean - #t if path exists and is a directory
+(define (is-dir? path)
+  (with-handler (lambda (err) #f)
+                (let* ([cmd (command "sh" (list "-c" (string-append "[ -d \"" path "\" ]")))]
+                       [child-result (spawn-process cmd)]
+                       [child (Ok->value child-result)]
+                       [exit-code-result (wait child)]
+                       [exit-code (Ok->value exit-code-result)])
+                  (equal? exit-code 0))))
+
+;;;; Directory Scanning ;;;;
+
+;;@doc
+;; Recursively scan directory for files matching patterns.
+;;
+;; Uses `find` command to traverse directories and locate project files.
+;; Returns list of absolute paths.
+;;
+;; Parameters:
+;;   root-dir - Root directory to scan
+;;   patterns - List of filename patterns (e.g., '("deps.edn" "bb.edn" "package.json"))
+;;
+;; Returns:
+;;   List of absolute file paths, or empty list on error
+;;
+;; Example:
+;;   (scan-directory-recursive "/workspace" '("deps.edn" "bb.edn"))
+;;   => ("/workspace/deps.edn" "/workspace/subproject/bb.edn")
+(define (scan-directory-recursive root-dir patterns)
+  (if (or (not root-dir) (null? patterns))
+      (list)
+      (with-handler
+       (lambda (err) (list)) ; Return empty list on error
+       (let* ([find-expr (build-find-expression patterns)]
+              [find-cmd
+               (string-append "find \"" root-dir "\" -type f \\( " find-expr " \\) 2>/dev/null")]
+              [cmd (command "sh" (list "-c" find-cmd))]
+              [_ (set-piped-stdout! cmd)]
+              [child-result (spawn-process cmd)])
+         (if (Err? child-result)
+             (list)
+             (let* ([child (Ok->value child-result)]
+                    [stdout-result (wait->stdout child)])
+               (if (Err? stdout-result)
+                   (list)
+                   (let* ([stdout-str (Ok->value stdout-result)]
+                          [split-lines (split-many stdout-str "\n")]
+                          [filtered-lines (filter (lambda (line) (not (string=? line "")))
+                                                  split-lines)])
+                     filtered-lines))))))))
+
+(define (build-find-expression patterns)
+  "Build find expression for -name patterns.
+   Example: '(\"deps.edn\" \"bb.edn\") => \"-name deps.edn -o -name bb.edn\""
+  (apply string-append
+         (let loop ([remaining patterns]
+                    [result (list)])
+           (if (null? remaining)
+               (reverse result)
+               (let ([pattern (car remaining)]
+                     [rest (cdr remaining)])
+                 (if (null? result)
+                     ;; First pattern - no -o prefix
+                     (loop rest (cons (string-append "-name \"" pattern "\"") result))
+                     ;; Subsequent patterns - add -o
+                     (loop rest
+                           (cons (string-append "-name \"" pattern "\"") (cons " -o " result)))))))))
+
+;;;; File Reading ;;;;
+
+;;@doc
+;; Read first N lines of file for preview.
+;;
+;; Parameters:
+;;   filepath - Path to file
+;;   max-lines - Maximum number of lines to read
+;;
+;; Returns:
+;;   String containing first max-lines of file, or #f on error
+;;
+;; Example:
+;;   (read-file-preview "/path/to/deps.edn" 50)
+(define (read-file-preview filepath max-lines)
+  (if (not (is-file? filepath))
+      #f
+      (with-handler (lambda (err) #f) ; Return #f on read error
+                    (let* ([port (open-input-file filepath)]
+                           [lines (read-lines port max-lines)])
+                      (close-input-port port)
+                      (if (null? lines)
+                          ""
+                          (apply string-append
+                                 (map (lambda (line) (string-append line "\n")) lines)))))))
+
+(define (read-lines port max-lines)
+  "Read up to max-lines from port. Returns list of strings."
+  (let loop ([count 0]
+             [result (list)])
+    (if (>= count max-lines)
+        (reverse result)
+        (let ([line (read-line-from-port port)])
+          (if (eof-object? line)
+              (reverse result)
+              (loop (+ count 1) (cons line result)))))))
+
+(define (read-line-from-port port)
+  "Read single line from port (without newline). Returns eof-object on EOF."
+  (let loop ([chars (list)])
+    (let ([ch (read-char port)])
+      (cond
+        [(eof-object? ch)
+         (if (null? chars)
+             ch
+             (list->string (reverse chars)))]
+        [(char=? ch #\newline) (list->string (reverse chars))]
+        [else (loop (cons ch chars))]))))
+
+;;;; Path Manipulation ;;;;
+
+;;@doc
+;; Convert absolute path to relative path from workspace root.
+;;
+;; Parameters:
+;;   absolute-path - Full path
+;;   workspace-root - Workspace root directory
+;;
+;; Returns:
+;;   Relative path string, or absolute path if conversion fails
+;;
+;; Example:
+;;   (get-relative-path "/workspace/sub/deps.edn" "/workspace")
+;;   => "sub/deps.edn"
+(define (get-relative-path absolute-path workspace-root)
+  (if (or (not absolute-path) (not workspace-root))
+      absolute-path
+      (let* ([root-with-slash (if (string-suffix? workspace-root "/")
+                                  workspace-root
+                                  (string-append workspace-root "/"))]
+             [root-len (string-length root-with-slash)])
+        (if (and (>= (string-length absolute-path) root-len)
+                 (string=? (substring absolute-path 0 root-len) root-with-slash))
+            ;; Path starts with workspace root - strip it
+            (substring absolute-path root-len (string-length absolute-path))
+            ;; Path doesn't start with workspace root - return as is
+            absolute-path))))
+
+(define (string-suffix? s suffix)
+  "Check if string s ends with suffix"
+  (let ([s-len (string-length s)]
+        [suffix-len (string-length suffix)])
+    (and (>= s-len suffix-len) (string=? (substring s (- s-len suffix-len) s-len) suffix))))
+
+;;;; File Sorting ;;;;
+
+;;@doc
+;; Sort files by distance from root (depth), then alphabetically.
+;;
+;; Files closer to the root (fewer directory levels) come first.
+;; Within the same depth, files are sorted alphabetically.
+;;
+;; Parameters:
+;;   files - List of absolute file paths
+;;   workspace-root - Workspace root directory
+;;
+;; Returns:
+;;   Sorted list of file paths
+;;
+;; Example:
+;;   (sort-files-by-distance '("/ws/deps.edn" "/ws/sub/bb.edn" "/ws/project.clj") "/ws")
+;;   => ("/ws/deps.edn" "/ws/project.clj" "/ws/sub/bb.edn")
+(define (sort-files-by-distance files workspace-root)
+  (if (or (null? files) (not workspace-root))
+      files
+      (let ([files-with-depth (map (lambda (filepath)
+                                     (let* ([rel-path (get-relative-path filepath workspace-root)]
+                                            [depth (count-path-separators rel-path)])
+                                       (list depth filepath)))
+                                   files)])
+        ;; Sort by depth first, then by filepath
+        (map (lambda (pair) (cadr pair))
+             (sort files-with-depth
+                   (lambda (a b)
+                     (let ([depth-a (car a)]
+                           [depth-b (car b)]
+                           [path-a (cadr a)]
+                           [path-b (cadr b)])
+                       (if (= depth-a depth-b)
+                           ;; Same depth - sort alphabetically
+                           (string<? path-a path-b)
+                           ;; Different depth - sort by depth
+                           (< depth-a depth-b)))))))))
+
+(define (count-path-separators path)
+  "Count number of '/' characters in path"
+  (let loop ([i 0]
+             [count 0])
+    (if (>= i (string-length path))
+        count
+        (loop (+ i 1)
+              (if (char=? (string-ref path i) #\/)
+                  (+ count 1)
+                  count)))))

--- a/cogs/nrepl/picker-utils.scm
+++ b/cogs/nrepl/picker-utils.scm
@@ -1,0 +1,148 @@
+;; Copyright (C) 2025 Tom Waddington
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU Affero General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; picker-utils.scm - Shared Picker UI Utilities
+;;;
+;;; Common rendering and layout functions for picker components.
+
+(require-builtin helix/components)
+(require (prefix-in helix. "helix/commands.scm"))
+(require "helix/misc.scm")
+(require "cogs/nrepl/format-docs.scm")
+
+(provide PAGE_SIZE
+         PREVIEW_SCROLL_DELTA
+         MIN_AREA_WIDTH_FOR_PREVIEW
+         SCROLL_PADDING
+         draw-filter-bar
+         calculate-scroll-offset
+         apply-two-pane-layout)
+
+;;;; Constants ;;;;
+
+;; Navigation
+(define PAGE_SIZE 10)
+;; Number of items to skip when using Ctrl-u/Ctrl-d (page up/down)
+
+(define PREVIEW_SCROLL_DELTA 10)
+;; Number of lines to scroll when using PageUp/PageDown in preview pane
+
+;; Layout
+(define MIN_AREA_WIDTH_FOR_PREVIEW 72)
+;; Minimum terminal width to show preview pane (otherwise single-pane mode)
+
+(define SCROLL_PADDING 5)
+;; Number of items to keep above selection when scrolling
+
+;;;; Filter Bar Rendering ;;;;
+
+;;@doc
+;; Draw standard Helix-style filter bar.
+;;
+;; Renders a filter input line with:
+;; - Filter text + cursor on left
+;; - Count "filtered/total" on right
+;;
+;; Parameters:
+;;   buffer      - Frame buffer for rendering
+;;   x           - X coordinate
+;;   y           - Y coordinate
+;;   width       - Available width
+;;   filter-text - Current filter string
+;;   filtered-count - Number of filtered items
+;;   total-count - Total number of items
+;;
+;; Example output: "myfilter█         23/487"
+(define (draw-filter-bar buffer x y width filter-text filtered-count total-count)
+  (let* ([cursor-char "█"]
+         [count-text (string-append (number->string filtered-count) "/" (number->string total-count))]
+         [count-len (string-length count-text)]
+         [text-style (style)]
+         [max-filter-width (- width count-len 1)])
+
+    ;; Clear the line
+    (frame-set-string! buffer x y (make-string width #\space) (style))
+
+    ;; Draw filter text with cursor (left side)
+    (let ([display-text (string-append filter-text cursor-char)])
+      (frame-set-string! buffer x y (truncate-string display-text max-filter-width) text-style))
+
+    ;; Draw count (right side)
+    (frame-set-string! buffer (+ x (- width count-len)) y count-text text-style)))
+
+;;;; Scroll Offset Calculation ;;;;
+
+;;@doc
+;; Calculate scroll offset to keep selection centered with padding.
+;;
+;; Uses conservative approach (not viewport-aware). Keeps SCROLL_PADDING
+;; items above the selected item when possible.
+;;
+;; Parameters:
+;;   new-index - The newly selected index
+;;
+;; Returns:
+;;   Scroll offset (non-negative integer)
+;;
+;; Example:
+;;   (calculate-scroll-offset 10)  => 5  (keeps 5 items above selection)
+;;   (calculate-scroll-offset 2)   => 0  (can't have 5 above when at top)
+(define (calculate-scroll-offset new-index)
+  (max 0 (- new-index SCROLL_PADDING)))
+
+;;;; Two-Pane Layout ;;;;
+
+;;@doc
+;; Calculate two-pane layout dimensions.
+;;
+;; Given an overlay area, returns layout info for picker and preview panes.
+;; If area is too narrow, preview is disabled (preview-area will be #f).
+;;
+;; Parameters:
+;;   overlay-area - Area struct (from apply-overlay-transform)
+;;
+;; Returns:
+;;   Hash with:
+;;     '#:show-preview - Boolean
+;;     '#:picker-area - Area struct for picker pane
+;;     '#:preview-area - Area struct for preview pane (or #f)
+;;     '#:picker-width - Width of picker pane
+;;     '#:preview-width - Width of preview pane (or 0)
+;;
+;; Example:
+;;   (apply-two-pane-layout area)
+;;   => (hash '#:show-preview #t '#:picker-area ... '#:preview-area ...)
+(define (apply-two-pane-layout overlay-area)
+  (let* ([overlay-width (area-width overlay-area)]
+         [overlay-height (area-height overlay-area)]
+         [overlay-x (area-x overlay-area)]
+         [overlay-y (area-y overlay-area)]
+         [show-preview (> overlay-width MIN_AREA_WIDTH_FOR_PREVIEW)]
+         [picker-width (if show-preview
+                           (quotient overlay-width 2)
+                           overlay-width)]
+         [picker-area (area overlay-x overlay-y picker-width overlay-height)]
+         [preview-area (if show-preview
+                           (area (+ overlay-x picker-width)
+                                 overlay-y
+                                 (- overlay-width picker-width)
+                                 overlay-height)
+                           #f)]
+         [preview-width (if show-preview
+                            (- overlay-width picker-width)
+                            0)])
+
+    (hash '#:show-preview
+          show-preview
+          '#:picker-area
+          picker-area
+          '#:preview-area
+          preview-area
+          '#:picker-width
+          picker-width
+          '#:preview-width
+          preview-width)))

--- a/cogs/nrepl/project-detection.scm
+++ b/cogs/nrepl/project-detection.scm
@@ -11,6 +11,8 @@
 (require "steel/result")
 (require-builtin steel/process)
 (require "cogs/nrepl/string-utils.scm")
+(require "cogs/nrepl/file-utils.scm")
+(require "cogs/nrepl/project-file-types.scm")
 
 (provide project-info
          make-project-info
@@ -20,7 +22,9 @@
          project-info-aliases
          project-info-has-nrepl-port?
          detect-project
+         detect-project-from-file
          find-project-files
+         find-project-files-recursive
          alias-info
          make-alias-info
          alias-info-name
@@ -85,46 +89,58 @@
   ;; Check if file exists first to avoid errors
   (if (not (is-file? deps-edn-path))
       (list) ; Return empty list if file doesn't exist
-      (let* ([content (read-port-to-string (open-input-file deps-edn-path))])
-        ;; Extract aliases with metadata
-        (extract-alias-info content))))
+      (let* ([content (read-port-to-string (open-input-file deps-edn-path))]
+             [aliases (extract-alias-info content)])
+        (helix.echo
+         (string-append "nREPL: Found " (to-string (length aliases)) " aliases in " deps-edn-path))
+        aliases)))
+
+(define (find-in-plist plist key)
+  "Find value for key in plist (alternating key-value list)"
+  (if (null? plist)
+      #f
+      (if (equal? (car plist) key)
+          (if (null? (cdr plist))
+              #f
+              (cadr plist))
+          (find-in-plist (cdr plist) key))))
 
 (define (extract-alias-info content)
-  "Extract alias information from deps.edn content.
-   Returns list of alias-info structs with name, has-main-opts?, description"
-  ;; Token-based approach: split on whitespace and braces, find keywords
-  (if (not (string-contains? content ":aliases"))
-      (list) ; No :aliases found
-      ;; Process entire content (filter will exclude non-alias keywords)
-      (let* ([property-keywords '(":extra-paths" ":extra-deps"
-                                                 ":main-opts"
-                                                 ":mvn/version"
-                                                 ":local/root"
-                                                 ":git/"
-                                                 ":sha"
-                                                 ":exclusions"
-                                                 ":override-deps"
-                                                 ":default-deps"
-                                                 ":classpath-overrides")]
-             ;; Tokenize on whitespace AND braces/brackets
-             [tokens (tokenize content " \t\n\r{}[]()")]
-             ;; Find all keywords (tokens starting with :)
-             [keywords
-              (filter (lambda (t)
-                        (and (string? t) (> (string-length t) 1) (equal? (substring t 0 1) ":")))
-                      tokens)]
-             ;; Filter out :aliases itself and known property keywords
-             [alias-keywords (filter (lambda (k)
-                                       (and (not (equal? k ":aliases"))
-                                            (not (member k property-keywords))))
-                                     keywords)])
-        ;; Create alias-info for each, checking for :main-opts nearby
-        (map (lambda (alias-kw)
-               (let* ([alias-name (substring alias-kw 1 (string-length alias-kw))]
-                      ;; Simple heuristic: check if ":main-opts" appears in same context
-                      [has-main? (string-contains? content (string-append alias-kw " {:main-opts"))])
-                 (make-alias-info alias-name has-main? #f)))
-             alias-keywords))))
+  "Extract alias information from deps.edn content using EDN parsing.
+   Returns list of alias-info structs with name, has-main-opts?, description.
+   Only returns TOP-LEVEL aliases, not nested keywords.
+
+   Note: Steel's read function parses EDN as S-expressions (plists),
+   so {:a 1 :b 2} becomes (:a 1 :b 2) as an alternating key-value list."
+  (let* ([data (read (open-input-string content))])
+    ;; data is a plist like (:deps ... :aliases ...)
+    (if (list? data)
+        (let ([aliases-value (find-in-plist data ':aliases)])
+          (if aliases-value
+              ;; aliases-value is also a plist like (:dev ... :test ... :poly ...)
+              (if (list? aliases-value)
+                  (let loop ([remaining aliases-value]
+                             [result (list)])
+                    (if (null? remaining)
+                        (reverse result)
+                        (if (null? (cdr remaining))
+                            (reverse result) ; Odd number of elements, done
+                            (let* ([alias-key (car remaining)]
+                                   [alias-config (cadr remaining)]
+                                   ;; Convert keyword to string (remove leading :)
+                                   [alias-name (let ([key-str (to-string alias-key)])
+                                                 (if (equal? (substring key-str 0 1) ":")
+                                                     (substring key-str 1 (string-length key-str))
+                                                     key-str))]
+                                   ;; Check if config has :main-opts
+                                   [has-main? (if (list? alias-config)
+                                                  (if (find-in-plist alias-config ':main-opts) #t #f)
+                                                  #f)])
+                              (loop (cddr remaining)
+                                    (cons (make-alias-info alias-name has-main? #f) result))))))
+                  (list))
+              (list)))
+        (list))))
 
 ;;; Project detection
 
@@ -165,3 +181,55 @@
       [(not (null? deps)) (car deps)]
       [(not (null? lein)) (car lein)]
       [else (car project-files)]))) ; Shouldn't reach here but return first as fallback
+
+;;;; Recursive Project File Detection ;;;;
+
+(define (find-project-files-recursive workspace-root)
+  "Recursively find all project files in workspace.
+   Returns list of absolute file paths.
+   Uses extensible project file type registry to scan for all known project files."
+  (if (not workspace-root)
+      (list)
+      (let* ([patterns (get-all-project-filenames)]
+             [found-files (scan-directory-recursive workspace-root patterns)])
+        found-files)))
+
+(define (detect-project-from-file filepath)
+  "Detect project info from specific project file path.
+   Returns project-info struct or #f if file doesn't exist or isn't recognized.
+
+   Parameters:
+     filepath - Absolute path to project file (e.g., \"/workspace/deps.edn\")
+
+   Returns:
+     project-info struct with project-type, project-root, etc., or #f"
+  (if (or (not filepath) (not (is-file? filepath)))
+      #f
+      (let* ([project-type (detect-file-type filepath)]
+             [project-root (extract-project-root filepath)])
+        (if (not project-type)
+            #f
+            (let* ([has-port? (has-nrepl-port-file? project-root)]
+                   [aliases (if (equal? project-type 'clojure-cli)
+                                (let* ([all-aliases (parse-deps-edn-aliases filepath)])
+                                  (if (null? all-aliases) #f all-aliases))
+                                #f)])
+              (make-project-info project-type project-root filepath aliases has-port?))))))
+
+(define (extract-project-root filepath)
+  "Extract project root directory from file path.
+   Returns directory containing the project file.
+   Example: \"/workspace/sub/deps.edn\" => \"/workspace/sub\""
+  (let ([last-slash (find-last-char filepath #\/)])
+    (if last-slash
+        (substring filepath 0 last-slash)
+        filepath)))
+
+(define (find-last-char s ch)
+  "Find index of last occurrence of char ch in string s. Returns index or #f."
+  (let ([len (string-length s)])
+    (let loop ([i (- len 1)])
+      (cond
+        [(< i 0) #f]
+        [(char=? (string-ref s i) ch) i]
+        [else (loop (- i 1))]))))

--- a/cogs/nrepl/project-file-picker.scm
+++ b/cogs/nrepl/project-file-picker.scm
@@ -1,0 +1,411 @@
+;; Copyright (C) 2025 Tom Waddington
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU Affero General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; project-file-picker.scm - Project File Picker Component
+;;;
+;;; Interactive picker for selecting project files when multiple are found.
+
+(require-builtin helix/components)
+(require-builtin steel/ports)
+(require (prefix-in helix. "helix/commands.scm"))
+(require (prefix-in helix.static. "helix/static.scm"))
+(require "helix/misc.scm")
+
+(require "cogs/nrepl/ui-utils.scm")
+(require "cogs/nrepl/picker-utils.scm")
+(require "cogs/nrepl/string-utils.scm")
+(require "cogs/nrepl/file-utils.scm")
+(require "cogs/nrepl/project-file-types.scm")
+(require "cogs/nrepl/format-docs.scm")
+
+(provide show-project-file-picker)
+
+;;;; Constants ;;;;
+
+(define PREVIEW_LINES 50)
+;; Number of lines to show in file preview
+
+;; Column layout
+(define MIN_COLUMN_DISPLAY_WIDTH 30) ; Minimum width to show all columns
+(define COLUMN_TYPE_WIDTH 16)
+(define COLUMN_SPACING 2)
+
+;;;; Component State Structure ;;;;
+
+(struct ProjectFilePickerState
+        (workspace-root ; String - workspace root directory
+         all-files ; List of absolute file paths (original full list)
+         filtered-files ; List of absolute file paths (current filtered view)
+         selected-index ; Integer - currently selected index into filtered-files
+         scroll-offset ; Integer - for scrolling long lists
+         filter-text ; String - user's filter input
+         preview-content ; Hash - filepath -> preview string cache
+         preview-scroll ; Integer - scroll offset for preview pane
+         preview-width ; Integer - current preview pane width
+         callback) ; Function - (filepath) -> void
+  #:transparent)
+
+(define (make-project-file-picker-state workspace-root files callback)
+  (let ([sorted-files (sort-files-by-distance files workspace-root)])
+    (ProjectFilePickerState workspace-root
+                            sorted-files ; Original full list (sorted)
+                            sorted-files ; Initially, filtered = full list
+                            0 ; selected-index starts at 0
+                            0 ; scroll-offset starts at 0
+                            "" ; empty filter text
+                            (hash) ; empty preview cache
+                            0 ; preview-scroll starts at 0
+                            60 ; default preview-width
+                            callback)))
+
+;;;; Public API ;;;;
+
+;;@doc
+;; Show project file picker component.
+;;
+;; Parameters:
+;;   workspace-root - Workspace root directory
+;;   files - List of absolute file paths to choose from
+;;   callback - Function called with selected file path
+;;
+;; Example:
+;;   (show-project-file-picker "/workspace"
+;;                             '("/workspace/deps.edn" "/workspace/bb.edn")
+;;                             (lambda (path) (helix.echo path)))
+(define (show-project-file-picker workspace-root files callback)
+  (if (or (null? files) (not workspace-root))
+      (helix.echo "No project files to select")
+      (let* ([state (make-project-file-picker-state workspace-root files callback)]
+             [state-box (box state)]
+             [function-map (hash "handle_event"
+                                 handle-picker-event
+                                 "cursor"
+                                 (lambda (state-box rect) #f)
+                                 "required_size"
+                                 (lambda (state-box size) size))]
+             [component (new-component! "project-file-picker" state-box render-picker function-map)])
+        (push-component! component))))
+
+;;;; Rendering ;;;;
+
+(define (render-picker state-box rect buffer)
+  "Render the project file picker component"
+  (let* ([state (unbox state-box)]
+         [overlay-area (apply-overlay-transform rect)]
+         [layout (apply-two-pane-layout overlay-area)]
+         [show-preview (hash-ref layout '#:show-preview)]
+         [picker-area (hash-ref layout '#:picker-area)]
+         [preview-area (hash-ref layout '#:preview-area)]
+         [picker-width (hash-ref layout '#:picker-width)]
+         [preview-width (hash-ref layout '#:preview-width)])
+
+    ;; Update preview width in state if changed
+    (when (not (= preview-width (ProjectFilePickerState-preview-width state)))
+      (set-box! state-box
+                (ProjectFilePickerState (ProjectFilePickerState-workspace-root state)
+                                        (ProjectFilePickerState-all-files state)
+                                        (ProjectFilePickerState-filtered-files state)
+                                        (ProjectFilePickerState-selected-index state)
+                                        (ProjectFilePickerState-scroll-offset state)
+                                        (ProjectFilePickerState-filter-text state)
+                                        (ProjectFilePickerState-preview-content state)
+                                        (ProjectFilePickerState-preview-scroll state)
+                                        preview-width
+                                        (ProjectFilePickerState-callback state))))
+
+    (buffer/clear buffer overlay-area)
+
+    ;; Draw borders
+    (let ([border-style (make-block (theme->bg *helix.cx*) (theme->bg *helix.cx*) "all" "plain")])
+      (block/render buffer picker-area border-style)
+      (when show-preview
+        (block/render buffer preview-area border-style)))
+
+    (let* ([picker-x (+ (area-x picker-area) 2)]
+           [picker-y (+ (area-y picker-area) 1)]
+           [picker-content-width (- picker-width 4)]
+           [picker-content-height (- (area-height picker-area) 2)]
+           [filter-y picker-y]
+           [separator-y (+ picker-y 1)]
+           [list-y (+ picker-y 2)]
+           [list-height (- picker-content-height 2)])
+
+      ;; Draw filter bar
+      (draw-filter-bar buffer
+                       picker-x
+                       filter-y
+                       picker-content-width
+                       (ProjectFilePickerState-filter-text state)
+                       (length (ProjectFilePickerState-filtered-files state))
+                       (length (ProjectFilePickerState-all-files state)))
+
+      ;; Draw separator
+      (frame-set-string! buffer picker-x separator-y (make-string picker-content-width #\─) (style))
+
+      ;; Draw column header
+      (draw-column-header buffer picker-x (+ separator-y 1) picker-content-width)
+
+      ;; Draw file list
+      (draw-file-list buffer picker-x (+ separator-y 2) picker-content-width (- list-height 1) state)
+
+      ;; Draw preview if enabled
+      (when show-preview
+        (let* ([preview-x (+ (area-x preview-area) 2)]
+               [preview-y (+ (area-y preview-area) 1)]
+               [preview-content-width (- preview-width 4)]
+               [preview-content-height (- (area-height preview-area) 2)])
+          (draw-preview buffer
+                        preview-x
+                        preview-y
+                        preview-content-width
+                        preview-content-height
+                        state))))))
+
+(define (draw-file-list buffer x y width height state)
+  "Draw scrollable list of files with columns (project file, type)"
+  (let* ([files (ProjectFilePickerState-filtered-files state)]
+         [workspace-root (ProjectFilePickerState-workspace-root state)]
+         [selected (ProjectFilePickerState-selected-index state)]
+         [scroll (ProjectFilePickerState-scroll-offset state)]
+         [visible-count (min height (length files))]
+         [start-index scroll]
+         [end-index (min (+ start-index visible-count) (length files))]
+         ;; Column widths - adjust based on available space with bounds checking
+         [type-width (if (< width MIN_COLUMN_DISPLAY_WIDTH) 0 COLUMN_TYPE_WIDTH)]
+         [spacing (if (< width MIN_COLUMN_DISPLAY_WIDTH) 0 COLUMN_SPACING)]
+         [path-width (max 10 (- width type-width spacing))])
+
+    (let loop ([i start-index])
+      (when (< i end-index)
+        (let* ([filepath (list-ref files i)]
+               [relative-path (get-relative-path filepath workspace-root)]
+               [type-label (get-file-type-label filepath)]
+               [row (+ y (- i scroll))]
+               [is-selected (= i selected)]
+               [style-obj (if is-selected
+                              (theme-scope *helix.cx* "ui.menu.selected")
+                              (style))]
+               ;; Build column display
+               [prefix (if is-selected "> " "  ")]
+               [path-col (truncate-left relative-path (- path-width 2))]
+               [type-col (truncate-string type-label type-width)]
+               ;; Pad columns to fixed width for alignment
+               [path-padded (string-append
+                             path-col
+                             (make-string (max 0 (- path-width (string-length path-col) 2)) #\space))]
+               [display-text (string-append prefix path-padded " " type-col)])
+
+          (frame-set-string! buffer x row (truncate-string display-text width) style-obj)
+          (loop (+ i 1)))))))
+
+(define (draw-preview buffer x y width height state)
+  "Draw file preview pane"
+  (let* ([selected-file (get-selected-file state)])
+    (if (not selected-file)
+        (frame-set-string! buffer x y "No file selected" (style-fg (style) Color/Gray))
+        (let ([preview-text (get-preview-content state selected-file)])
+          (if (not preview-text)
+              (frame-set-string! buffer x y "Could not load preview" (style-fg (style) Color/Gray))
+              (draw-preview-text buffer x y width height state preview-text))))))
+
+(define (draw-preview-text buffer x y width height state preview-text)
+  "Draw scrollable preview text"
+  (let* ([lines (split-many preview-text "\n")]
+         [scroll (ProjectFilePickerState-preview-scroll state)]
+         [visible-count (min height (length lines))]
+         [start-line scroll]
+         [end-line (min (+ start-line visible-count) (length lines))])
+
+    (let loop ([i start-line])
+      (when (< i end-line)
+        (let* ([line (list-ref lines i)]
+               [row (+ y (- i scroll))])
+          (frame-set-string! buffer x row (truncate-string line width) (style))
+          (loop (+ i 1)))))))
+
+(define (draw-column-header buffer x y width)
+  "Draw fixed column header row"
+  (let* ([type-width (if (< width MIN_COLUMN_DISPLAY_WIDTH) 0 COLUMN_TYPE_WIDTH)]
+         [spacing (if (< width MIN_COLUMN_DISPLAY_WIDTH) 0 COLUMN_SPACING)]
+         [path-width (max 10 (- width type-width spacing))]
+         [prefix "  "]
+         ;; Pad headers to match column widths
+         [path-header (if (> path-width 12)
+                          (string-append "Project File"
+                                         (make-string (max 0 (- path-width 12 2)) #\space))
+                          "Project File")]
+         [type-header (if (> type-width 0) "Type" "")]
+         [header-parts (filter (lambda (s) (not (string=? s ""))) (list path-header type-header))]
+         [header-text (string-append prefix
+                                     (apply string-append
+                                            (map (lambda (part)
+                                                   (if (string=? part (car (reverse header-parts)))
+                                                       part
+                                                       (string-append part " ")))
+                                                 header-parts)))]
+         [header-style (style)])
+
+    (frame-set-string! buffer x y (truncate-string header-text width) header-style)))
+
+;;;; State Management ;;;;
+
+(define (get-selected-file state)
+  "Get currently selected file path"
+  (let* ([filtered (ProjectFilePickerState-filtered-files state)]
+         [index (ProjectFilePickerState-selected-index state)])
+    (if (and (>= index 0) (< index (length filtered)))
+        (list-ref filtered index)
+        #f)))
+
+(define (get-preview-content state filepath)
+  "Get preview content from cache or load it"
+  (let ([cache (ProjectFilePickerState-preview-content state)])
+    (if (hash-contains? cache filepath)
+        (hash-ref cache filepath)
+        (let ([content (read-file-preview filepath PREVIEW_LINES)])
+          ;; Update cache (but don't modify state here - just for this render)
+          content))))
+
+(define (apply-filter state new-filter)
+  "Filter files by substring match and return new state
+   Note: Maintains sort order (by distance from root, then alphabetically)"
+  (let* ([all-files (ProjectFilePickerState-all-files state)]
+         [workspace-root (ProjectFilePickerState-workspace-root state)]
+         [filtered (if (string=? new-filter "")
+                       all-files
+                       ;; Filter maintains order since all-files is already sorted
+                       (filter (lambda (filepath)
+                                 (let ([relative (get-relative-path filepath workspace-root)])
+                                   (string-contains-ci? relative new-filter)))
+                               all-files))])
+
+    (ProjectFilePickerState workspace-root
+                            all-files
+                            filtered
+                            0 ; Reset to first item
+                            0 ; Reset scroll
+                            new-filter
+                            (ProjectFilePickerState-preview-content state)
+                            0 ; Reset preview scroll
+                            (ProjectFilePickerState-preview-width state)
+                            (ProjectFilePickerState-callback state))))
+
+(define (move-selection state-box delta)
+  "Move selection by delta with wrapping"
+  (let* ([state (unbox state-box)]
+         [filtered (ProjectFilePickerState-filtered-files state)]
+         [count (length filtered)]
+         [current (ProjectFilePickerState-selected-index state)])
+    (when (> count 0)
+      (let* ([next (+ current delta)]
+             [new-index (cond
+                          [(< next 0) (- count 1)]
+                          [(>= next count) 0]
+                          [else next])]
+             [new-scroll (calculate-scroll-offset new-index)])
+        (set-box! state-box
+                  (ProjectFilePickerState (ProjectFilePickerState-workspace-root state)
+                                          (ProjectFilePickerState-all-files state)
+                                          filtered
+                                          new-index
+                                          new-scroll
+                                          (ProjectFilePickerState-filter-text state)
+                                          (ProjectFilePickerState-preview-content state)
+                                          0 ; Reset preview scroll when changing selection
+                                          (ProjectFilePickerState-preview-width state)
+                                          (ProjectFilePickerState-callback state)))))))
+
+(define (scroll-preview state-box delta)
+  "Scroll preview pane by delta lines"
+  (let* ([state (unbox state-box)]
+         [current-scroll (ProjectFilePickerState-preview-scroll state)]
+         [new-scroll (max 0 (+ current-scroll delta))])
+    (set-box! state-box
+              (ProjectFilePickerState (ProjectFilePickerState-workspace-root state)
+                                      (ProjectFilePickerState-all-files state)
+                                      (ProjectFilePickerState-filtered-files state)
+                                      (ProjectFilePickerState-selected-index state)
+                                      (ProjectFilePickerState-scroll-offset state)
+                                      (ProjectFilePickerState-filter-text state)
+                                      (ProjectFilePickerState-preview-content state)
+                                      new-scroll
+                                      (ProjectFilePickerState-preview-width state)
+                                      (ProjectFilePickerState-callback state)))))
+
+;;;; Event Handling ;;;;
+
+(define (handle-picker-event state-box event)
+  "Handle keyboard events for picker"
+  (cond
+    ;; Escape - cancel
+    [(key-event-escape? event) event-result/close]
+
+    ;; Enter - select and invoke callback
+    [(key-event-enter? event)
+     (let* ([state (unbox state-box)]
+            [selected (get-selected-file state)]
+            [callback (ProjectFilePickerState-callback state)])
+       (when (and selected callback)
+         (callback selected))
+       event-result/close)]
+
+    ;; Backspace - remove last filter char
+    [(key-event-backspace? event)
+     (let* ([state (unbox state-box)]
+            [filter-text (ProjectFilePickerState-filter-text state)])
+       (if (> (string-length filter-text) 0)
+           (let ([new-filter (substring filter-text 0 (- (string-length filter-text) 1))])
+             (set-box! state-box (apply-filter state new-filter)))
+           void)
+       event-result/consume)]
+
+    ;; Navigation - Up/Down, j/k, Ctrl-p/Ctrl-n
+    [(or (key-event-up? event)
+         (and (key-event-char event)
+              (equal? (key-event-char event) #\k)
+              (not (key-event-modifier event))))
+     (move-selection state-box -1)
+     event-result/consume]
+
+    [(or (key-event-down? event)
+         (and (key-event-char event)
+              (equal? (key-event-char event) #\j)
+              (not (key-event-modifier event))))
+     (move-selection state-box 1)
+     event-result/consume]
+
+    [(and (key-event-char event)
+          (equal? (key-event-char event) #\p)
+          (equal? (key-event-modifier event) key-modifier-ctrl))
+     (move-selection state-box -1)
+     event-result/consume]
+
+    [(and (key-event-char event)
+          (equal? (key-event-char event) #\n)
+          (equal? (key-event-modifier event) key-modifier-ctrl))
+     (move-selection state-box 1)
+     event-result/consume]
+
+    ;; Preview scrolling
+    [(key-event-page-up? event)
+     (scroll-preview state-box (- PREVIEW_SCROLL_DELTA))
+     event-result/consume]
+
+    [(key-event-page-down? event)
+     (scroll-preview state-box PREVIEW_SCROLL_DELTA)
+     event-result/consume]
+
+    ;; Character input - add to filter
+    [(key-event-char event)
+     (let* ([state (unbox state-box)]
+            [char (key-event-char event)]
+            [filter-text (ProjectFilePickerState-filter-text state)]
+            [new-filter (string-append filter-text (string char))])
+       (set-box! state-box (apply-filter state new-filter))
+       event-result/consume)]
+
+    [else event-result/consume]))

--- a/cogs/nrepl/project-file-types.scm
+++ b/cogs/nrepl/project-file-types.scm
@@ -1,0 +1,179 @@
+;; Copyright (C) 2025 Tom Waddington
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU Affero General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; project-file-types.scm - Extensible Project File Type Registry
+;;;
+;;; Defines known project file types and provides detection/labeling functions.
+
+(provide PROJECT_FILE_TYPES
+         detect-file-type
+         get-file-type-label
+         get-file-type-language
+         get-all-project-filenames)
+
+;;;; Project File Type Registry ;;;;
+
+;; Structure: (filename project-type label language)
+;; - filename: Exact filename to match (e.g., "deps.edn")
+;; - project-type: Symbol identifier (e.g., 'clojure-cli)
+;; - label: Human-readable description (e.g., "Clojure CLI")
+;; - language: Programming language (e.g., "Clojure")
+
+(define PROJECT_FILE_TYPES
+  (list (list "deps.edn" 'clojure-cli "Clojure CLI" "Clojure")
+        (list "bb.edn" 'babashka "Babashka" "Clojure")
+        (list "project.clj" 'leiningen "Leiningen" "Clojure")
+        (list "shadow-cljs.edn" 'shadow-cljs "Shadow CLJS" "ClojureScript")
+        ;; Python
+        (list "pyproject.toml" 'python-poetry "Python Poetry" "Python")
+        (list "setup.py" 'python-setuptools "Python Setuptools" "Python")
+        (list "Pipfile" 'python-pipenv "Python Pipenv" "Python")
+        (list "requirements.txt" 'python-pip "Python Pip" "Python")))
+
+;; POSSIBLE FUTURE SUPPORT
+;; JavaScript/TypeScript
+; (list "package.json" 'npm "Node.js/NPM" "JavaScript")
+; (list "deno.json" 'deno "Deno" "JavaScript")
+; (list "bun.lockb" 'bun "Bun" "JavaScript")
+;; Rust
+; (list "Cargo.toml" 'rust-cargo "Rust Cargo" "Rust")
+;; Go
+; (list "go.mod" 'go-modules "Go Modules" "Go")
+;; Ruby
+; (list "Gemfile" 'ruby-bundler "Ruby Bundler" "Ruby")
+;; Java/JVM
+; (list "pom.xml" 'maven "Maven" "Java")
+; (list "build.gradle" 'gradle "Gradle" "Java")
+; (list "build.gradle.kts" 'gradle-kotlin "Gradle Kotlin DSL" "Kotlin")
+;; Other
+; (list "Makefile" 'make "Makefile" "Make")
+; (list "CMakeLists.txt" 'cmake "CMake" "C/C++"
+
+;;;; Detection Functions ;;;;
+
+;;@doc
+;; Detect project file type from filepath.
+;;
+;; Parameters:
+;;   filepath - Absolute or relative path to project file
+;;
+;; Returns:
+;;   Project type symbol (e.g., 'clojure-cli), or #f if unknown
+;;
+;; Example:
+;;   (detect-file-type "/workspace/deps.edn") => 'clojure-cli
+;;   (detect-file-type "/workspace/unknown.txt") => #f
+(define (detect-file-type filepath)
+  (if (not filepath)
+      #f
+      (let ([filename (extract-filename filepath)])
+        (let loop ([types PROJECT_FILE_TYPES])
+          (if (null? types)
+              #f
+              (let* ([entry (car types)]
+                     [pattern (car entry)]
+                     [project-type (cadr entry)])
+                (if (string=? filename pattern)
+                    project-type
+                    (loop (cdr types)))))))))
+
+;;@doc
+;; Get human-readable label for project file type.
+;;
+;; Parameters:
+;;   filepath - Absolute or relative path to project file
+;;
+;; Returns:
+;;   Label string (e.g., "Clojure CLI"), or "Unknown" if not recognized
+;;
+;; Example:
+;;   (get-file-type-label "/workspace/deps.edn") => "Clojure CLI"
+(define (get-file-type-label filepath)
+  (if (not filepath)
+      "Unknown"
+      (let ([filename (extract-filename filepath)])
+        (let loop ([types PROJECT_FILE_TYPES])
+          (if (null? types)
+              "Unknown"
+              (let* ([entry (car types)]
+                     [pattern (car entry)]
+                     [label (caddr entry)])
+                (if (string=? filename pattern)
+                    label
+                    (loop (cdr types)))))))))
+
+;;@doc
+;; Get programming language for project file.
+;;
+;; Parameters:
+;;   filepath - Absolute or relative path to project file
+;;
+;; Returns:
+;;   Language string (e.g., "Clojure"), or "Unknown" if not recognized
+;;
+;; Example:
+;;   (get-file-type-language "/workspace/deps.edn") => "Clojure"
+(define (get-file-type-language filepath)
+  (if (not filepath)
+      "Unknown"
+      (let ([filename (extract-filename filepath)])
+        (let loop ([types PROJECT_FILE_TYPES])
+          (if (null? types)
+              "Unknown"
+              (let* ([entry (car types)]
+                     [pattern (car entry)]
+                     [language (cadddr entry)])
+                (if (string=? filename pattern)
+                    language
+                    (loop (cdr types)))))))))
+
+;;@doc
+;; Get list of all known project filenames for scanning.
+;;
+;; Returns:
+;;   List of filename strings (e.g., '("deps.edn" "bb.edn" ...))
+;;
+;; Example:
+;;   (get-all-project-filenames)
+;;   => ("deps.edn" "bb.edn" "project.clj" "package.json" ...)
+(define (get-all-project-filenames)
+  (map car PROJECT_FILE_TYPES))
+
+;;;; Helper Functions ;;;;
+
+(define (extract-filename filepath)
+  "Extract filename from path (last component after /).
+   Example: \"/path/to/deps.edn\" => \"deps.edn\""
+  (let ([parts (split-path filepath)])
+    (if (null? parts)
+        filepath
+        (car (reverse parts)))))
+
+(define (split-path path)
+  "Split path on / into list of components"
+  (let loop ([start 0]
+             [result (list)])
+    (let ([slash-pos (find-char-in-string path #\/ start)])
+      (if (not slash-pos)
+          ;; No more slashes - add final part
+          (reverse (cons (substring path start (string-length path)) result))
+          ;; Found slash - extract part and continue
+          (let ([part (substring path start slash-pos)])
+            (loop (+ slash-pos 1)
+                  (if (string=? part "")
+                      result ; Skip empty parts (e.g., leading /)
+                      (cons part result))))))))
+
+(define (find-char-in-string s ch start)
+  "Find first occurrence of char ch in string s starting at index start.
+   Returns index or #f if not found."
+  (let ([len (string-length s)])
+    (let loop ([i start])
+      (cond
+        [(>= i len) #f]
+        [(char=? (string-ref s i) ch) i]
+        [else (loop (+ i 1))]))))

--- a/cogs/nrepl/sorting-utils.scm
+++ b/cogs/nrepl/sorting-utils.scm
@@ -1,0 +1,90 @@
+;; Copyright (C) 2025 Tom Waddington
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU Affero General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; sorting-utils.scm - Sorting Utilities
+;;;
+;;; General-purpose sorting functions for Steel Scheme.
+;;; Based on merge-sort from steel-resources/steel/cogs/sorting/merge-sort.scm
+
+(provide sort)
+
+;;;; Merge Sort Implementation ;;;;
+
+;;@doc
+;; Merge two sorted lists using a comparator function.
+;;
+;; Parameters:
+;;   l1 - First sorted list
+;;   l2 - Second sorted list
+;;   comparator - Function (a b) -> boolean, returns #t if a should come before b
+;;
+;; Returns:
+;;   Merged sorted list
+(define (merge-lists l1 l2 comparator)
+  (if (null? l1)
+      l2
+      (if (null? l2)
+          l1
+          (if (comparator (car l1) (car l2))
+              (cons (car l1) (merge-lists (cdr l1) l2 comparator))
+              (cons (car l2) (merge-lists (cdr l2) l1 comparator))))))
+
+;;@doc
+;; Extract elements at even positions from list.
+;;
+;; Parameters:
+;;   l - Input list
+;;
+;; Returns:
+;;   List of elements at even positions (0-indexed: 2nd, 4th, 6th, etc.)
+(define (even-elements l)
+  (if (null? l)
+      '()
+      (if (null? (cdr l))
+          '()
+          (cons (car (cdr l)) (even-elements (cdr (cdr l)))))))
+
+;;@doc
+;; Extract elements at odd positions from list.
+;;
+;; Parameters:
+;;   l - Input list
+;;
+;; Returns:
+;;   List of elements at odd positions (0-indexed: 1st, 3rd, 5th, etc.)
+(define (odd-elements l)
+  (if (null? l)
+      '()
+      (if (null? (cdr l))
+          (list (car l))
+          (cons (car l) (odd-elements (cdr (cdr l)))))))
+
+;;@doc
+;; Sort a list using merge sort algorithm.
+;;
+;; Stable sort - maintains relative order of equal elements.
+;;
+;; Parameters:
+;;   l - List to sort
+;;   comparator - Function (a b) -> boolean, returns #t if a should come before b
+;;
+;; Returns:
+;;   Sorted list
+;;
+;; Examples:
+;;   (sort '(3 1 4 1 5 9) <)           => (1 1 3 4 5 9)
+;;   (sort '("foo" "bar" "baz") string<?)  => ("bar" "baz" "foo")
+;;   (sort '((2 "b") (1 "a") (2 "c"))
+;;         (lambda (a b) (< (car a) (car b))))  => ((1 "a") (2 "b") (2 "c"))
+(define (sort l comparator)
+  (if (null? l)
+      l
+      (if (null? (cdr l))
+          l
+          (merge-lists (sort (odd-elements l) comparator)
+                       (sort (even-elements l) comparator)
+                       comparator))))


### PR DESCRIPTION
 - Add string utilities for case-insensitive search
 - Add picker-utils shared module
 - Refactor lookup-picker to use shared utilities
 - Add file-utils module for recursive scanning
 - Add extensible project file type registry
 - Add project file picker component
 - Update project-detection for recursive scan
 - Integrate project file picker into jack-in